### PR TITLE
Move and test some of the CLI logic

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
     install_requires=[
         'docopt',
         'jinja2',
+        'schema>=0.6.7,<1'
         'termcolor',
     ],
 

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     install_requires=[
         'docopt',
         'jinja2',
-        'schema>=0.6.7,<1'
+        'schema>=0.6.7,<1',
         'termcolor',
     ],
 

--- a/src/itpe/cli.py
+++ b/src/itpe/cli.py
@@ -25,6 +25,9 @@ from schema import Schema, And, Or, Use, SchemaError
 def get_args(argv):
     args = docopt.docopt(doc=__doc__, argv=argv)
 
+    if args['--output'] is None:
+        args['--output'] = os.path.splitext(args['--input'])[0] + '.html'
+
     schema = Schema({
         # These two keys get handled by docopt, so we just need to validate
         # that they've not been passed.
@@ -35,16 +38,13 @@ def get_args(argv):
         # file, and we shouldn't try to overwrite an existing file.  At some
         # point it might be nice to allow overriding the output rule with
         # '--force', but that adds unnecessary complication.
-        '--input': Use(
+        '--input': And(
             lambda f: open(f, 'r'),
             error='--input=%r should be readable' % args['--input']
         ),
-        '--output': Or(
-            None,
-            And(
-                not os.path.exists,
-                error='--output=%r already exists!' % args['--output']
-            )
+        '--output': And(
+            lambda f: not os.path.exists(f),
+            error='--output=%r already exists!' % args['--output']
         ),
         '--width': Or(
             None,

--- a/src/itpe/cli.py
+++ b/src/itpe/cli.py
@@ -1,0 +1,61 @@
+# -*- encoding: utf-8
+"""
+Generate the HTML for the #ITPE master post.
+
+Usage:
+  itpe_generator.py --input <INPUT> [--output <OUTPUT>] [--width=<WIDTH>]
+  itpe_generator.py (-h | --help)
+  itpe_generator.py --version
+
+Options:
+  -h --help           Show this screen.
+  --input=<INPUT>     CSV file containing the ITPE data.
+  --output=<OUTPUT>   HTML file for writing the generated HTML.
+  --width=<WIDTH>     Width of the cover art in px [default: 500].
+
+"""
+
+import os
+import sys
+
+import docopt
+from schema import Schema, And, Or, Use, SchemaError
+
+
+def get_args(argv):
+    args = docopt.docopt(doc=__doc__, argv=argv)
+
+    schema = Schema({
+        # These two keys get handled by docopt, so we just need to validate
+        # that they've not been passed.
+        '--help': False,
+        '--version': False,
+
+        # These are safety precautions: we shouldn't try to read an existing
+        # file, and we shouldn't try to overwrite an existing file.  At some
+        # point it might be nice to allow overriding the output rule with
+        # '--force', but that adds unnecessary complication.
+        '--input': Use(
+            lambda f: open(f, 'r'),
+            error='--input=%r should be readable' % args['--input']
+        ),
+        '--output': Or(
+            None,
+            And(
+                not os.path.exists,
+                error='--output=%r already exists!' % args['--output']
+            )
+        ),
+        '--width': Or(
+            None,
+            And(
+                Use(int),
+                lambda w: w > 0,
+                error='--width=%r should be a positive integer' % args['--width']
+            )
+        ),
+    })
+
+    args = schema.validate(args)
+
+    return args

--- a/src/itpe/cli.py
+++ b/src/itpe/cli.py
@@ -16,14 +16,13 @@ Options:
 """
 
 import os
-import sys
 
 import docopt
-from schema import Schema, And, Or, Use, SchemaError
+from schema import Schema, And, Or, Use
 
 
-def get_args(argv):
-    args = docopt.docopt(doc=__doc__, argv=argv)
+def get_args(argv, *args, **kwargs):
+    args = docopt.docopt(doc=__doc__, argv=argv, *args, **kwargs)
 
     if args['--output'] is None:
         args['--output'] = os.path.splitext(args['--input'])[0] + '.html'
@@ -51,7 +50,9 @@ def get_args(argv):
             And(
                 Use(int),
                 lambda w: w > 0,
-                error='--width=%r should be a positive integer' % args['--width']
+                error=(
+                    '--width=%r should be a positive integer' %
+                    args['--width'])
             )
         ),
     })

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -40,3 +40,8 @@ def test_errors_are_helpful(example_file, argv, expected_message):
 def test_width_arg_is_converted_to_int():
     parsed_args = cli.get_args(['--input', 'tox.ini', '--width', '50'])
     assert parsed_args['--width'] == 50
+
+
+def test_guesses_sensible_output_if_not_provided(example_file):
+    parsed_args = cli.get_args(['--input', 'example.csv'])
+    assert parsed_args['--output'] == 'example.html'

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,24 +1,37 @@
 # -*- encoding: utf-8
 
+import os
+
 import pytest
 from schema import SchemaError
 
 from itpe import cli
 
 
+@pytest.fixture
+def example_file(tmpdir):
+    curdir = os.path.abspath(os.curdir)
+    try:
+        os.chdir(tmpdir)
+        open('example.csv', 'w').write('')
+        yield
+    finally:
+        os.chdir(curdir)
+
+
 @pytest.mark.parametrize('argv, expected_message', [
     (['--input', 'doesnotexist.csv'],
      "--input='doesnotexist.csv' should be readable"),
 
-    (['--input', 'tox.ini', '--width', '-5'],
+    (['--input', 'example.csv', '--width', '-5'],
      "--width='-5' should be a positive integer"),
-    (['--input', 'tox.ini', '--width', '6xx'],
+    (['--input', 'example.csv', '--width', '6xx'],
      "--width='6xx' should be a positive integer"),
 
-    (['--input', 'tox.ini', '--output', 'tox.ini'],
-     "--output='tox.ini' already exists!"),
+    (['--input', 'example.csv', '--output', 'example.csv'],
+     "--output='example.csv' already exists!"),
 ])
-def test_errors_are_helpful(argv, expected_message):
+def test_errors_are_helpful(example_file, argv, expected_message):
     with pytest.raises(SchemaError) as err:
         cli.get_args(argv)
     assert str(err.value) == expected_message

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,29 @@
+# -*- encoding: utf-8
+
+import pytest
+from schema import SchemaError
+
+from itpe import cli
+
+
+@pytest.mark.parametrize('argv, expected_message', [
+    (['--input', 'doesnotexist.csv'],
+     "--input='doesnotexist.csv' should be readable"),
+
+    (['--input', 'tox.ini', '--width', '-5'],
+     "--width='-5' should be a positive integer"),
+    (['--input', 'tox.ini', '--width', '6xx'],
+     "--width='6xx' should be a positive integer"),
+
+    (['--input', 'tox.ini', '--output', 'tox.ini'],
+     "--output='tox.ini' already exists!"),
+])
+def test_errors_are_helpful(argv, expected_message):
+    with pytest.raises(SchemaError) as err:
+        cli.get_args(argv)
+    assert str(err.value) == expected_message
+
+
+def test_width_arg_is_converted_to_int():
+    parsed_args = cli.get_args(['--input', 'tox.ini', '--width', '50'])
+    assert parsed_args['--width'] == 50


### PR DESCRIPTION
Related: #6 

Since this script has a fairly simple interface, I thought it would be easier to test – and then I discovered [data validation](https://github.com/docopt/docopt#data-validation) in the docopt README, and decided to give it a try on this project.

This should make the error reporting slightly more helpful, and reduce the risk of accidentally overwriting the wrong file.